### PR TITLE
BUG: Check for correct probe array size

### DIFF
--- a/src/ptychocg/solver.py
+++ b/src/ptychocg/solver.py
@@ -1,5 +1,6 @@
 """Module for 2D ptychography."""
 
+import warnings
 import numpy as np
 import cupy as cp
 import sys
@@ -74,11 +75,12 @@ class Solver(object):
             gamma *= 0.5
         if(gamma <= 1e-32):  # direction not found
             gamma = 0
+            warnings.warn("Line search failed for conjugate gradient.")
         return gamma
 
     # Conjugate gradients for ptychography
     def cg_ptycho(self, data, psi, scan, prb, piter, model):
-
+        assert prb.ndim == 3, "prb needs 3 dimensions, not %d" % prb.ndim
         # minimization functional
         def minf(psi, fpsi):
             if model == 'gaussian':
@@ -88,7 +90,8 @@ class Solver(object):
             return f
 
         # initial gradient steps
-        gammapsi = 1
+        gammapsi = 1 / (cp.max(cp.abs(prb)**2))
+        assert cp.isfinite(gammapsi), "The probe amplitude cannot be zero."
         # gammaprb = 1 # # under development
         for i in range(piter):
             # 1) CG update psi with fixed prb
@@ -147,6 +150,7 @@ class Solver(object):
 
     # Solve ptycho by angles partitions
     def cg_ptycho_batch(self, data, initpsi, scan, initprb, piter, model):
+        assert prb.ndim == 3, "prb needs 3 dimensions, not %d" % prb.ndim
         psi = initpsi.copy()
         prb = initprb.copy()
 
@@ -155,5 +159,5 @@ class Solver(object):
             datap = cp.array(data[ids])  # copy a part of data to GPU
             # solve cg ptychography problem for the part
             psi[ids], prb[ids] = self.cg_ptycho(
-                datap, psi[ids], scan[:, ids], prb[ids], piter, model)
+                datap, psi[ids], scan[:, ids], prb[ids, :, :], piter, model)
         return psi, prb


### PR DESCRIPTION
Having the wrong array size for the probe can lead to infinite
gradient step sizes if the slice given contains only zeros. This
commit adds assertions to check that the probe is the right size,
does not contain NaNs, has a non-zero amplitude, and adds helpful
warnings about infinite line searches.