### PR TITLE
API: Modularize the Solver base class and convert it to a context manager 

### DIFF
--- a/src/cuda/ptychofft.cu
+++ b/src/cuda/ptychofft.cu
@@ -2,40 +2,40 @@
 #include "kernels.cuh"
 
 // constructor, memory allocation
-ptychofft::ptychofft(size_t Ntheta_, size_t Nz_, size_t N_,
-					 size_t Nscan_, size_t Ndetx_, size_t Ndety_, size_t Nprb_)
+ptychofft::ptychofft(size_t ntheta_, size_t nz_, size_t n_,
+					 size_t nscan_, size_t ndetx_, size_t ndety_, size_t nprb_)
 {
 	// init sizes
-	N = N_;
-	Ntheta = Ntheta_;
-	Nz = Nz_;
-	Nscan = Nscan_;
-	Ndetx = Ndetx_;
-	Ndety = Ndety_;
-	Nprb = Nprb_;
+	n = n_;
+	ntheta = ntheta_;
+	nz = nz_;
+	nscan = nscan_;
+	ndetx = ndetx_;
+	ndety = ndety_;
+	nprb = nprb_;
 
 	// allocate memory on GPU
-	cudaMalloc((void **)&f, Ntheta * Nz * N * sizeof(float2));
-	cudaMalloc((void **)&g, Ntheta * Nscan * Ndetx * Ndety * sizeof(float2));
-	cudaMalloc((void **)&scanx, Ntheta * Nscan * sizeof(float));
-	cudaMalloc((void **)&scany, Ntheta * Nscan * sizeof(float));
-	cudaMalloc((void **)&shiftx, Ntheta * Nscan * sizeof(float2));
-	cudaMalloc((void **)&shifty, Ntheta * Nscan * sizeof(float2));
-	cudaMalloc((void **)&prb, Ntheta * Nprb * Nprb * sizeof(float2));
+	cudaMalloc((void **)&f, ntheta * nz * n * sizeof(float2));
+	cudaMalloc((void **)&g, ntheta * nscan * ndetx * ndety * sizeof(float2));
+	cudaMalloc((void **)&scanx, ntheta * nscan * sizeof(float));
+	cudaMalloc((void **)&scany, ntheta * nscan * sizeof(float));
+	cudaMalloc((void **)&shiftx, ntheta * nscan * sizeof(float2));
+	cudaMalloc((void **)&shifty, ntheta * nscan * sizeof(float2));
+	cudaMalloc((void **)&prb, ntheta * nprb * nprb * sizeof(float2));
 
-	// create batched 2d FFT plan on GPU with sizes (Ndetx,Ndety)
+	// create batched 2d FFT plan on GPU with sizes (ndetx,ndety)
 	int ffts[2];
-	ffts[0] = Ndetx;
-	ffts[1] = Ndety;
-	cufftPlanMany(&plan2d, 2, ffts, ffts, 1, Ndetx * Ndety, ffts, 1, Ndetx * Ndety, CUFFT_C2C, Ntheta * Nscan);
+	ffts[0] = ndetx;
+	ffts[1] = ndety;
+	cufftPlanMany(&plan2d, 2, ffts, ffts, 1, ndetx * ndety, ffts, 1, ndetx * ndety, CUFFT_C2C, ntheta * nscan);
 
-	// create batched 2d FFT plan on GPU with sizes (Nprb,Nprb)	acting on arrays with sizes (Ndetx,Ndety)
-	ffts[0] = Nprb;
-	ffts[1] = Nprb;
+	// create batched 2d FFT plan on GPU with sizes (nprb,nprb)	acting on arrays with sizes (ndetx,ndety)
+	ffts[0] = nprb;
+	ffts[1] = nprb;
 	int inembed[2];
-	inembed[0] = Ndetx;
-	inembed[1] = Ndety;
-	cufftPlanMany(&plan2dshift, 2, ffts, inembed, 1, Ndetx * Ndety, inembed, 1, Ndetx * Ndety, CUFFT_C2C, Ntheta * Nscan);
+	inembed[0] = ndetx;
+	inembed[1] = ndety;
+	cufftPlanMany(&plan2dshift, 2, ffts, inembed, 1, ndetx * ndety, inembed, 1, ndetx * ndety, CUFFT_C2C, ntheta * nscan);
 
 	// init 3d thread block on GPU
 	BS3d.x = 32;
@@ -43,16 +43,16 @@ ptychofft::ptychofft(size_t Ntheta_, size_t Nz_, size_t N_,
 	BS3d.z = 1;
 
 	// init 3d thread grids	on GPU
-	GS3d0.x = ceil(Nprb * Nprb / (float)BS3d.x);
-	GS3d0.y = ceil(Nscan / (float)BS3d.y);
-	GS3d0.z = ceil(Ntheta / (float)BS3d.z);
+	GS3d0.x = ceil(nprb * nprb / (float)BS3d.x);
+	GS3d0.y = ceil(nscan / (float)BS3d.y);
+	GS3d0.z = ceil(ntheta / (float)BS3d.z);
 
-	GS3d1.x = ceil(Ndetx * Ndety / (float)BS3d.x);
-	GS3d1.y = ceil(Nscan / (float)BS3d.y);
-	GS3d1.z = ceil(Ntheta / (float)BS3d.z);
+	GS3d1.x = ceil(ndetx * ndety / (float)BS3d.x);
+	GS3d1.y = ceil(nscan / (float)BS3d.y);
+	GS3d1.z = ceil(ntheta / (float)BS3d.z);
 
-	GS3d2.x = ceil(Nscan / (float)BS3d.x);
-	GS3d2.y = ceil(Ntheta / (float)BS3d.y);
+	GS3d2.x = ceil(nscan / (float)BS3d.x);
+	GS3d2.y = ceil(ntheta / (float)BS3d.y);
 	GS3d2.z = 1;
 }
 
@@ -73,81 +73,81 @@ ptychofft::~ptychofft()
 void ptychofft::fwd(size_t g_, size_t f_, size_t scan_, size_t prb_)
 {
 	// copy arrays to GPU
-	cudaMemcpy(f, (float2 *)f_, Ntheta * Nz * N * sizeof(float2), cudaMemcpyDefault);
-	cudaMemset(g, 0, Ntheta * Nscan * Ndetx * Ndety * sizeof(float2));
-	cudaMemcpy(scanx, &((float *)scan_)[0], Ntheta * Nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(scany, &((float *)scan_)[Ntheta * Nscan], Ntheta * Nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(prb, (float2 *)prb_, Ntheta * Nprb * Nprb * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy(f, (float2 *)f_, ntheta * nz * n * sizeof(float2), cudaMemcpyDefault);
+	cudaMemset(g, 0, ntheta * nscan * ndetx * ndety * sizeof(float2));
+	cudaMemcpy(scanx, &((float *)scan_)[0], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(scany, &((float *)scan_)[ntheta * nscan], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(prb, (float2 *)prb_, ntheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
 
 	// take part for the probe multiplication and shift it via FFT
-	takepart<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, Ntheta, Nz, N, Nscan, Nprb, Ndetx, Ndety);
+	takepart<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
 
 	//// SHIFT start
 	// Fourier transform
 	cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 	// compute exp(1j dx),exp(1j dy) where dx,dy are in (-1,1) and correspond to shifts to nearest integer
-	takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, 1, Ntheta, Nscan);
+	takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, 1, ntheta, nscan);
 	// perform shifts in the frequency domain by multiplication with exp(1j dx),exp(1j dy)
-	shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, Ntheta, Nscan, Ndetx * Ndety, Nprb*Nprb);
+	shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ntheta, nscan, ndetx * ndety, nprb*nprb);
 	// inverse Fourier transform
 	cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 	//// SHIFT end
 
 	// probe multiplication of the object array
-	mulprobe<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, Ntheta, Nz, N, Nscan, Nprb, Ndetx, Ndety);
+	mulprobe<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
 	// Fourier transform
 	cufftExecC2C(plan2d, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 
 	// copy result to CPU
-	cudaMemcpy((float2 *)g_, g, Ntheta * Nscan * Ndetx * Ndety * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy((float2 *)g_, g, ntheta * nscan * ndetx * ndety * sizeof(float2), cudaMemcpyDefault);
 }
 
 // adjoint ptychography operator with respect to object (flg==0) f = Q*F*g, or probe (flg==1) prb = Q*F*g
 void ptychofft::adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg)
 {
 	// copy arrays to GPU
-	cudaMemcpy(f, (float2 *)f_, Ntheta * Nz * N * sizeof(float2),cudaMemcpyDefault);	
-	cudaMemcpy(g, (float2 *)g_, Ntheta * Nscan * Ndetx * Ndety * sizeof(float2), cudaMemcpyDefault);
-	cudaMemcpy(scanx, &((float *)scan_)[0], Ntheta * Nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(scany, &((float *)scan_)[Ntheta * Nscan], Ntheta * Nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(prb, (float2 *)prb_, Ntheta * Nprb * Nprb * sizeof(float2), cudaMemcpyDefault);
-	
+	cudaMemcpy(f, (float2 *)f_, ntheta * nz * n * sizeof(float2),cudaMemcpyDefault);
+	cudaMemcpy(g, (float2 *)g_, ntheta * nscan * ndetx * ndety * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy(scanx, &((float *)scan_)[0], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(scany, &((float *)scan_)[ntheta * nscan], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(prb, (float2 *)prb_, ntheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
+
 	// inverse Fourier transform
 	cufftExecC2C(plan2d, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 	if (flg == 0)// adjoint probe multiplication operator
 	{
-		mulaprobe<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, Ntheta, Nz, N, Nscan, Nprb, Ndetx, Ndety);
+		mulaprobe<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
 
 		//// SHIFT start
 		// Fourier transform
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 		// compute exp(1j dx),exp(1j dy) where dx,dy are in (-1,1) and correspond to shifts to nearest integer
-		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, Ntheta, Nscan);		
+		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, ntheta, nscan);
 		// perform shifts in the frequency domain by multiplication with exp(-1j dx),exp(-1j dy) - backward
-		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, Ntheta, Nscan, Ndetx * Ndety, Nprb*Nprb);
+		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ntheta, nscan, ndetx * ndety, nprb*nprb);
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 		//// SHIFT end
 
-		setpartobj<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, Ntheta, Nz, N, Nscan, Nprb, Ndetx, Ndety);
+		setpartobj<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
 		// copy result to CPU
-		cudaMemcpy((float2 *)f_, f, Ntheta * Nz * N * sizeof(float2), cudaMemcpyDefault);
+		cudaMemcpy((float2 *)f_, f, ntheta * nz * n * sizeof(float2), cudaMemcpyDefault);
 	}
 	else if (flg == 1)// adjoint object multiplication operator
-	{		
-		mulaobj<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, Ntheta, Nz, N, Nscan, Nprb, Ndetx, Ndety);
-		
+	{
+		mulaobj<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+
 		//// SHIFT start
 		// Fourier transform
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 		// compute exp(1j dx),exp(1j dy) where dx,dy are in (-1,1) and correspond to shifts to nearest integer
-		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, Ntheta, Nscan);		
+		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, ntheta, nscan);
 		// perform shifts in the frequency domain by multiplication with exp(-1j dx),exp(-1j dy) - backward
-		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, Ntheta, Nscan, Ndetx * Ndety, Nprb*Nprb);
+		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ntheta, nscan, ndetx * ndety, nprb*nprb);
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 		//// SHIFT end
 
-		setpartprobe<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, Ntheta, Nz, N, Nscan, Nprb, Ndetx, Ndety);				
+		setpartprobe<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
 		// copy result to CPU
-		cudaMemcpy((float2 *)prb_, prb, Ntheta * Nprb * Nprb * sizeof(float2), cudaMemcpyDefault);
+		cudaMemcpy((float2 *)prb_, prb, ntheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
 	}
 }

--- a/src/cuda/ptychofft.cu
+++ b/src/cuda/ptychofft.cu
@@ -2,26 +2,26 @@
 #include "kernels.cuh"
 
 // constructor, memory allocation
-ptychofft::ptychofft(size_t ntheta, size_t nz, size_t n, size_t nscan,
+ptychofft::ptychofft(size_t ptheta, size_t nz, size_t n, size_t nscan,
   size_t ndetx, size_t ndety, size_t nprb
 ) :
-  ntheta(ntheta), nz(nz), n(n), nscan(nscan), ndetx(ndetx), ndety(ndety),
+  ptheta(ptheta), nz(nz), n(n), nscan(nscan), ndetx(ndetx), ndety(ndety),
   nprb(nprb)
 {
 	// allocate memory on GPU
-	cudaMalloc((void **)&f, ntheta * nz * n * sizeof(float2));
-	cudaMalloc((void **)&g, ntheta * nscan * ndetx * ndety * sizeof(float2));
-	cudaMalloc((void **)&scanx, ntheta * nscan * sizeof(float));
-	cudaMalloc((void **)&scany, ntheta * nscan * sizeof(float));
-	cudaMalloc((void **)&shiftx, ntheta * nscan * sizeof(float2));
-	cudaMalloc((void **)&shifty, ntheta * nscan * sizeof(float2));
-	cudaMalloc((void **)&prb, ntheta * nprb * nprb * sizeof(float2));
+	cudaMalloc((void **)&f, ptheta * nz * n * sizeof(float2));
+	cudaMalloc((void **)&g, ptheta * nscan * ndetx * ndety * sizeof(float2));
+	cudaMalloc((void **)&scanx, ptheta * nscan * sizeof(float));
+	cudaMalloc((void **)&scany, ptheta * nscan * sizeof(float));
+	cudaMalloc((void **)&shiftx, ptheta * nscan * sizeof(float2));
+	cudaMalloc((void **)&shifty, ptheta * nscan * sizeof(float2));
+	cudaMalloc((void **)&prb, ptheta * nprb * nprb * sizeof(float2));
 
 	// create batched 2d FFT plan on GPU with sizes (ndetx,ndety)
 	int ffts[2];
 	ffts[0] = ndetx;
 	ffts[1] = ndety;
-	cufftPlanMany(&plan2d, 2, ffts, ffts, 1, ndetx * ndety, ffts, 1, ndetx * ndety, CUFFT_C2C, ntheta * nscan);
+	cufftPlanMany(&plan2d, 2, ffts, ffts, 1, ndetx * ndety, ffts, 1, ndetx * ndety, CUFFT_C2C, ptheta * nscan);
 
 	// create batched 2d FFT plan on GPU with sizes (nprb,nprb)	acting on arrays with sizes (ndetx,ndety)
 	ffts[0] = nprb;
@@ -29,7 +29,7 @@ ptychofft::ptychofft(size_t ntheta, size_t nz, size_t n, size_t nscan,
 	int inembed[2];
 	inembed[0] = ndetx;
 	inembed[1] = ndety;
-	cufftPlanMany(&plan2dshift, 2, ffts, inembed, 1, ndetx * ndety, inembed, 1, ndetx * ndety, CUFFT_C2C, ntheta * nscan);
+	cufftPlanMany(&plan2dshift, 2, ffts, inembed, 1, ndetx * ndety, inembed, 1, ndetx * ndety, CUFFT_C2C, ptheta * nscan);
 
 	// init 3d thread block on GPU
 	BS3d.x = 32;
@@ -39,14 +39,14 @@ ptychofft::ptychofft(size_t ntheta, size_t nz, size_t n, size_t nscan,
 	// init 3d thread grids	on GPU
 	GS3d0.x = ceil(nprb * nprb / (float)BS3d.x);
 	GS3d0.y = ceil(nscan / (float)BS3d.y);
-	GS3d0.z = ceil(ntheta / (float)BS3d.z);
+	GS3d0.z = ceil(ptheta / (float)BS3d.z);
 
 	GS3d1.x = ceil(ndetx * ndety / (float)BS3d.x);
 	GS3d1.y = ceil(nscan / (float)BS3d.y);
-	GS3d1.z = ceil(ntheta / (float)BS3d.z);
+	GS3d1.z = ceil(ptheta / (float)BS3d.z);
 
 	GS3d2.x = ceil(nscan / (float)BS3d.x);
-	GS3d2.y = ceil(ntheta / (float)BS3d.y);
+	GS3d2.y = ceil(ptheta / (float)BS3d.y);
 	GS3d2.z = 1;
 }
 
@@ -67,81 +67,81 @@ ptychofft::~ptychofft()
 void ptychofft::fwd(size_t g_, size_t f_, size_t scan_, size_t prb_)
 {
 	// copy arrays to GPU
-	cudaMemcpy(f, (float2 *)f_, ntheta * nz * n * sizeof(float2), cudaMemcpyDefault);
-	cudaMemset(g, 0, ntheta * nscan * ndetx * ndety * sizeof(float2));
-	cudaMemcpy(scanx, &((float *)scan_)[0], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(scany, &((float *)scan_)[ntheta * nscan], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(prb, (float2 *)prb_, ntheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy(f, (float2 *)f_, ptheta * nz * n * sizeof(float2), cudaMemcpyDefault);
+	cudaMemset(g, 0, ptheta * nscan * ndetx * ndety * sizeof(float2));
+	cudaMemcpy(scanx, &((float *)scan_)[0], ptheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(scany, &((float *)scan_)[ptheta * nscan], ptheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(prb, (float2 *)prb_, ptheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
 
 	// take part for the probe multiplication and shift it via FFT
-	takepart<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+	takepart<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, ptheta, nz, n, nscan, nprb, ndetx, ndety);
 
 	//// SHIFT start
 	// Fourier transform
 	cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 	// compute exp(1j dx),exp(1j dy) where dx,dy are in (-1,1) and correspond to shifts to nearest integer
-	takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, 1, ntheta, nscan);
+	takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, 1, ptheta, nscan);
 	// perform shifts in the frequency domain by multiplication with exp(1j dx),exp(1j dy)
-	shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ntheta, nscan, ndetx * ndety, nprb*nprb);
+	shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ptheta, nscan, ndetx * ndety, nprb*nprb);
 	// inverse Fourier transform
 	cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 	//// SHIFT end
 
 	// probe multiplication of the object array
-	mulprobe<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+	mulprobe<<<GS3d0, BS3d>>>(g, f, prb, scanx, scany, ptheta, nz, n, nscan, nprb, ndetx, ndety);
 	// Fourier transform
 	cufftExecC2C(plan2d, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 
 	// copy result to CPU
-	cudaMemcpy((float2 *)g_, g, ntheta * nscan * ndetx * ndety * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy((float2 *)g_, g, ptheta * nscan * ndetx * ndety * sizeof(float2), cudaMemcpyDefault);
 }
 
 // adjoint ptychography operator with respect to object (flg==0) f = Q*F*g, or probe (flg==1) prb = Q*F*g
 void ptychofft::adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg)
 {
 	// copy arrays to GPU
-	cudaMemcpy(f, (float2 *)f_, ntheta * nz * n * sizeof(float2),cudaMemcpyDefault);
-	cudaMemcpy(g, (float2 *)g_, ntheta * nscan * ndetx * ndety * sizeof(float2), cudaMemcpyDefault);
-	cudaMemcpy(scanx, &((float *)scan_)[0], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(scany, &((float *)scan_)[ntheta * nscan], ntheta * nscan * sizeof(float), cudaMemcpyDefault);
-	cudaMemcpy(prb, (float2 *)prb_, ntheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy(f, (float2 *)f_, ptheta * nz * n * sizeof(float2),cudaMemcpyDefault);
+	cudaMemcpy(g, (float2 *)g_, ptheta * nscan * ndetx * ndety * sizeof(float2), cudaMemcpyDefault);
+	cudaMemcpy(scanx, &((float *)scan_)[0], ptheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(scany, &((float *)scan_)[ptheta * nscan], ptheta * nscan * sizeof(float), cudaMemcpyDefault);
+	cudaMemcpy(prb, (float2 *)prb_, ptheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
 
 	// inverse Fourier transform
 	cufftExecC2C(plan2d, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 	if (flg == 0)// adjoint probe multiplication operator
 	{
-		mulaprobe<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+		mulaprobe<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, ptheta, nz, n, nscan, nprb, ndetx, ndety);
 
 		//// SHIFT start
 		// Fourier transform
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 		// compute exp(1j dx),exp(1j dy) where dx,dy are in (-1,1) and correspond to shifts to nearest integer
-		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, ntheta, nscan);
+		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, ptheta, nscan);
 		// perform shifts in the frequency domain by multiplication with exp(-1j dx),exp(-1j dy) - backward
-		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ntheta, nscan, ndetx * ndety, nprb*nprb);
+		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ptheta, nscan, ndetx * ndety, nprb*nprb);
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 		//// SHIFT end
 
-		setpartobj<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+		setpartobj<<<GS3d0, BS3d>>>(f, g, prb, scanx, scany, ptheta, nz, n, nscan, nprb, ndetx, ndety);
 		// copy result to CPU
-		cudaMemcpy((float2 *)f_, f, ntheta * nz * n * sizeof(float2), cudaMemcpyDefault);
+		cudaMemcpy((float2 *)f_, f, ptheta * nz * n * sizeof(float2), cudaMemcpyDefault);
 	}
 	else if (flg == 1)// adjoint object multiplication operator
 	{
-		mulaobj<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+		mulaobj<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, ptheta, nz, n, nscan, nprb, ndetx, ndety);
 
 		//// SHIFT start
 		// Fourier transform
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_FORWARD);
 		// compute exp(1j dx),exp(1j dy) where dx,dy are in (-1,1) and correspond to shifts to nearest integer
-		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, ntheta, nscan);
+		takeshifts<<<GS3d2, BS3d>>>(shiftx, shifty, scanx, scany, -1, ptheta, nscan);
 		// perform shifts in the frequency domain by multiplication with exp(-1j dx),exp(-1j dy) - backward
-		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ntheta, nscan, ndetx * ndety, nprb*nprb);
+		shifts<<<GS3d1, BS3d>>>(g, shiftx, shifty, ptheta, nscan, ndetx * ndety, nprb*nprb);
 		cufftExecC2C(plan2dshift, (cufftComplex *)g, (cufftComplex *)g, CUFFT_INVERSE);
 		//// SHIFT end
 
-		setpartprobe<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, ntheta, nz, n, nscan, nprb, ndetx, ndety);
+		setpartprobe<<<GS3d0, BS3d>>>(prb, g, f, scanx, scany, ptheta, nz, n, nscan, nprb, ndetx, ndety);
 		// copy result to CPU
-		cudaMemcpy((float2 *)prb_, prb, ntheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
+		cudaMemcpy((float2 *)prb_, prb, ptheta * nprb * nprb * sizeof(float2), cudaMemcpyDefault);
 	}
 }

--- a/src/cuda/ptychofft.cu
+++ b/src/cuda/ptychofft.cu
@@ -2,18 +2,12 @@
 #include "kernels.cuh"
 
 // constructor, memory allocation
-ptychofft::ptychofft(size_t ntheta_, size_t nz_, size_t n_,
-					 size_t nscan_, size_t ndetx_, size_t ndety_, size_t nprb_)
+ptychofft::ptychofft(size_t ntheta, size_t nz, size_t n, size_t nscan,
+  size_t ndetx, size_t ndety, size_t nprb
+) :
+  ntheta(ntheta), nz(nz), n(n), nscan(nscan), ndetx(ndetx), ndety(ndety),
+  nprb(nprb)
 {
-	// init sizes
-	n = n_;
-	ntheta = ntheta_;
-	nz = nz_;
-	nscan = nscan_;
-	ndetx = ndetx_;
-	ndety = ndety_;
-	nprb = nprb_;
-
 	// allocate memory on GPU
 	cudaMalloc((void **)&f, ntheta * nz * n * sizeof(float2));
 	cudaMalloc((void **)&g, ntheta * nscan * ndetx * ndety * sizeof(float2));

--- a/src/cuda/ptychofft.cu
+++ b/src/cuda/ptychofft.cu
@@ -53,14 +53,23 @@ ptychofft::ptychofft(size_t ptheta, size_t nz, size_t n, size_t nscan,
 // destructor, memory deallocation
 ptychofft::~ptychofft()
 {
-	cudaFree(f);
-	cudaFree(g);
-	cudaFree(scanx);
-	cudaFree(scany);
-	cudaFree(shiftx);
-	cudaFree(shifty);
-	cudaFree(prb);
-	cufftDestroy(plan2d);
+  free();
+}
+
+void ptychofft::free()
+{
+  if(!is_free)
+  {
+    cudaFree(f);
+    cudaFree(g);
+    cudaFree(scanx);
+    cudaFree(scany);
+    cudaFree(shiftx);
+    cudaFree(shifty);
+    cudaFree(prb);
+    cufftDestroy(plan2d);
+    is_free = true;
+  }
 }
 
 // forward ptychography operator g = FQf

--- a/src/cuda/ptychofft.i
+++ b/src/cuda/ptychofft.i
@@ -14,7 +14,9 @@ import_array();
 
 class ptychofft
 {
-	float2 *f;		// object
+  bool is_free = false;
+
+  float2 *f;		// object
 	float2 *g;		// data
 	float2 *prb;	// probe function
 	float *scanx;   // x scan positions
@@ -52,4 +54,5 @@ public:
 	void fwd(size_t g_, size_t f_, size_t scan_, size_t prb_);
 	// adjoint ptychography operator with respect to object (fgl==0) f = Q*F*g, or probe (flg==1) prb = Q*F*g
 	void adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg);
+  void free();
 };

--- a/src/cuda/ptychofft.i
+++ b/src/cuda/ptychofft.i
@@ -34,7 +34,7 @@ class ptychofft
 
 public:
   %immutable;
-  size_t ntheta; // number of projections
+  size_t ptheta; // number of projections
   size_t nz;	 // object vertical size
   size_t n;	  // object horizontal size
   size_t nscan;  // number of scan positions for 1 projection
@@ -44,12 +44,12 @@ public:
   %mutable;
 
 	// constructor, memory allocation
-	ptychofft(size_t ntheta, size_t nz, size_t n,
+	ptychofft(size_t ptheta, size_t nz, size_t n,
 			  size_t nscan, size_t ndetx, size_t ndety, size_t nprb);
 	// destructor, memory deallocation
 	~ptychofft();
 	// forward ptychography operator FQ
 	void fwd(size_t g_, size_t f_, size_t scan_, size_t prb_);
 	// adjoint ptychography operator with respect to object (fgl==0) f = Q*F*g, or probe (flg==1) prb = Q*F*g
-	void adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg);	
+	void adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg);
 };

--- a/src/cuda/ptychofft.i
+++ b/src/cuda/ptychofft.i
@@ -14,14 +14,6 @@ import_array();
 
 class ptychofft
 {
-	size_t N;	  // object horizontal size
-	size_t Nz;	 // object vertical size
-	size_t Ntheta; // number of projections
-	size_t Nscan;  // number of scan positions for 1 projection
-	size_t Ndetx;  // detector x size
-	size_t Ndety;  // detector y size
-	size_t Nprb;   // probe size in 1 dimension
-
 	float2 *f;		// object
 	float2 *g;		// data
 	float2 *prb;	// probe function
@@ -41,6 +33,16 @@ class ptychofft
 	dim3 GS3d2;
 
 public:
+  %immutable;
+  size_t Ntheta; // number of projections
+  size_t Nz;	 // object vertical size
+  size_t N;	  // object horizontal size
+  size_t Nscan;  // number of scan positions for 1 projection
+  size_t Ndetx;  // detector x size
+  size_t Ndety;  // detector y size
+  size_t Nprb;   // probe size in 1 dimension
+  %mutable;
+
 	// constructor, memory allocation
 	ptychofft(size_t Ntheta, size_t Nz, size_t N,
 			  size_t Nscan, size_t Ndetx, size_t Ndety, size_t Nprb);

--- a/src/cuda/ptychofft.i
+++ b/src/cuda/ptychofft.i
@@ -34,18 +34,18 @@ class ptychofft
 
 public:
   %immutable;
-  size_t Ntheta; // number of projections
-  size_t Nz;	 // object vertical size
-  size_t N;	  // object horizontal size
-  size_t Nscan;  // number of scan positions for 1 projection
-  size_t Ndetx;  // detector x size
-  size_t Ndety;  // detector y size
-  size_t Nprb;   // probe size in 1 dimension
+  size_t ntheta; // number of projections
+  size_t nz;	 // object vertical size
+  size_t n;	  // object horizontal size
+  size_t nscan;  // number of scan positions for 1 projection
+  size_t ndetx;  // detector x size
+  size_t ndety;  // detector y size
+  size_t nprb;   // probe size in 1 dimension
   %mutable;
 
 	// constructor, memory allocation
-	ptychofft(size_t Ntheta, size_t Nz, size_t N,
-			  size_t Nscan, size_t Ndetx, size_t Ndety, size_t Nprb);
+	ptychofft(size_t ntheta, size_t nz, size_t n,
+			  size_t nscan, size_t ndetx, size_t ndety, size_t nprb);
 	// destructor, memory deallocation
 	~ptychofft();
 	// forward ptychography operator FQ

--- a/src/include/ptychofft.cuh
+++ b/src/include/ptychofft.cuh
@@ -2,6 +2,8 @@
 
 class ptychofft
 {
+  bool is_free = false;
+
 	float2 *f;		// object
 	float2 *g;		// data
 	float2 *prb;	// probe function
@@ -38,4 +40,5 @@ public:
 	void fwd(size_t g_, size_t f_, size_t scan_, size_t prb_);
 	// adjoint ptychography operator with respect to object (fgl==0) f = Q*F*g, or probe (flg==1) prb = Q*F*g
 	void adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg);
+  void free();
 };

--- a/src/include/ptychofft.cuh
+++ b/src/include/ptychofft.cuh
@@ -2,14 +2,6 @@
 
 class ptychofft
 {
-	size_t N;	  // object horizontal size
-	size_t Nz;	 // object vertical size
-	size_t Ntheta; // number of projections
-	size_t Nscan;  // number of scan positions for 1 projection
-	size_t Ndetx;  // detector x size
-	size_t Ndety;  // detector y size
-	size_t Nprb;   // probe size in 1 dimension
-
 	float2 *f;		// object
 	float2 *g;		// data
 	float2 *prb;	// probe function
@@ -29,6 +21,14 @@ class ptychofft
 	dim3 GS3d2;
 
 public:
+  size_t Ntheta; // number of projections
+  size_t Nz;	 // object vertical size
+  size_t N;	  // object horizontal size
+  size_t Nscan;  // number of scan positions for 1 projection
+  size_t Ndetx;  // detector x size
+  size_t Ndety;  // detector y size
+  size_t Nprb;   // probe size in 1 dimension
+
 	// constructor, memory allocation
 	ptychofft(size_t Ntheta, size_t Nz, size_t N,
 			  size_t Nscan, size_t Ndetx, size_t Ndety, size_t Nprb);

--- a/src/include/ptychofft.cuh
+++ b/src/include/ptychofft.cuh
@@ -21,7 +21,7 @@ class ptychofft
 	dim3 GS3d2;
 
 public:
-  size_t ntheta; // number of projections
+  size_t ptheta; // number of projections
   size_t nz;	 // object vertical size
   size_t n;	  // object horizontal size
   size_t nscan;  // number of scan positions for 1 projection
@@ -30,12 +30,12 @@ public:
   size_t nprb;   // probe size in 1 dimension
 
 	// constructor, memory allocation
-	ptychofft(size_t ntheta, size_t nz, size_t n,
+	ptychofft(size_t ptheta, size_t nz, size_t n,
 			  size_t nscan, size_t ndetx, size_t ndety, size_t nprb);
 	// destructor, memory deallocation
 	~ptychofft();
 	// forward ptychography operator FQ
 	void fwd(size_t g_, size_t f_, size_t scan_, size_t prb_);
 	// adjoint ptychography operator with respect to object (fgl==0) f = Q*F*g, or probe (flg==1) prb = Q*F*g
-	void adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg);	
+	void adj(size_t f_, size_t g_, size_t scan_, size_t prb_, int flg);
 };

--- a/src/include/ptychofft.cuh
+++ b/src/include/ptychofft.cuh
@@ -21,17 +21,17 @@ class ptychofft
 	dim3 GS3d2;
 
 public:
-  size_t Ntheta; // number of projections
-  size_t Nz;	 // object vertical size
-  size_t N;	  // object horizontal size
-  size_t Nscan;  // number of scan positions for 1 projection
-  size_t Ndetx;  // detector x size
-  size_t Ndety;  // detector y size
-  size_t Nprb;   // probe size in 1 dimension
+  size_t ntheta; // number of projections
+  size_t nz;	 // object vertical size
+  size_t n;	  // object horizontal size
+  size_t nscan;  // number of scan positions for 1 projection
+  size_t ndetx;  // detector x size
+  size_t ndety;  // detector y size
+  size_t nprb;   // probe size in 1 dimension
 
 	// constructor, memory allocation
-	ptychofft(size_t Ntheta, size_t Nz, size_t N,
-			  size_t Nscan, size_t Ndetx, size_t Ndety, size_t Nprb);
+	ptychofft(size_t ntheta, size_t nz, size_t n,
+			  size_t nscan, size_t ndetx, size_t ndety, size_t nprb);
 	// destructor, memory deallocation
 	~ptychofft();
 	// forward ptychography operator FQ

--- a/src/ptychocg/solver.py
+++ b/src/ptychocg/solver.py
@@ -75,7 +75,6 @@ class PtychoCuFFT(object):
 
     def __exit__(self, type, value, traceback):
         """Free GPU memory due at interruptions or with-block exit."""
-        print("__exit__ was called.")
         del self.cl_ptycho
 
     def fwd_ptycho(self, psi, scan, prb):

--- a/src/ptychocg/solver.py
+++ b/src/ptychocg/solver.py
@@ -79,6 +79,9 @@ class PtychoCuFFT(object):
 
     def fwd_ptycho(self, psi, scan, prb):
         """Ptychography transform (FQ)"""
+        assert psi.dtype == cp.complex64, f"{psi.dtype}"
+        assert scan.dtype == cp.float32, f"{scan.dtype}"
+        assert prb.dtype == cp.complex64, f"{prb.dtype}"
         res = cp.zeros([self.ptheta, self.nscan, self.ndety,
                         self.ndetx], dtype='complex64')
         self.cl_ptycho.fwd(res.data.ptr, psi.data.ptr,
@@ -87,6 +90,9 @@ class PtychoCuFFT(object):
 
     def fwd_ptycho_batch(self, psi, scan, prb):
         """Batch of Ptychography transform (FQ)"""
+        assert psi.dtype == cp.complex64, f"{psi.dtype}"
+        assert scan.dtype == cp.float32, f"{scan.dtype}"
+        assert prb.dtype == cp.complex64, f"{prb.dtype}"
         data = np.zeros([self.ntheta, self.nscan, self.ndety,
                          self.ndetx], dtype='float32')
         for k in range(0, self.ntheta//self.ptheta):  # angle partitions in ptychography
@@ -98,6 +104,9 @@ class PtychoCuFFT(object):
 
     def adj_ptycho(self, data, scan, prb):
         """Adjoint ptychography transform (Q*F*)"""
+        assert data.dtype == cp.complex64, f"{data.dtype}"
+        assert scan.dtype == cp.float32, f"{scan.dtype}"
+        assert prb.dtype == cp.complex64, f"{prb.dtype}"
         res = cp.zeros([self.ptheta, self.nz, self.n],
                        dtype='complex64')
         flg = 0  # compute adjoint operator with respect to object
@@ -107,8 +116,12 @@ class PtychoCuFFT(object):
 
     def adj_ptycho_prb(self, data, scan, psi):
         """Adjoint ptychography probe transform (O*F*), object is fixed"""
+        assert data.dtype == cp.complex64, f"{data.dtype}"
+        assert scan.dtype == cp.float32, f"{scan.dtype}"
+        assert psi.dtype == cp.complex64, f"{psi.dtype}"
         res = cp.zeros([self.ptheta, self.nprb, self.nprb],
                        dtype='complex64')
+
         flg = 1  # compute adjoint operator with respect to probe
         self.cl_ptycho.adj(psi.data.ptr, data.data.ptr,
                            scan.data.ptr, res.data.ptr, flg)  # C++ wrapper, send pointers to GPU arrays

--- a/tests/test.py
+++ b/tests/test.py
@@ -52,20 +52,20 @@ if __name__ == "__main__":
     psi0[0] = psiamp*cp.exp(1j*psiang)
 
     # Class gpu solver
-    slv = pt.Solver(nscan, nprb, ndetx, ndety, ntheta, nz, n, ptheta)
-    # Compute data
-    data = slv.fwd_ptycho_batch(psi0, scan, prb0)
-    dxchange.write_tiff(data, 'data', overwrite=True)
+    with pt.CGPtychoSolver(nscan, nprb, ndetx, ndety, ntheta, nz, n, ptheta) as slv:
+        # Compute data
+        data = slv.fwd_ptycho_batch(psi0, scan, prb0)
+        dxchange.write_tiff(data, 'data', overwrite=True)
 
-    # Initial guess
-    psi = cp.ones([ntheta, nz, n], dtype='complex64')
-    if (recover_prb):
-        # Choose an adequate probe approximation
-        prb = prb0.copy().swapaxes(1, 2)
-    else:
-        prb = prb0.copy()
-    psi, prb = slv.cg_ptycho_batch(
-        data, psi, scan, prb, piter, model, recover_prb)
+        # Initial guess
+        psi = cp.ones([ntheta, nz, n], dtype='complex64')
+        if (recover_prb):
+            # Choose an adequate probe approximation
+            prb = prb0.copy().swapaxes(1, 2)
+        else:
+            prb = prb0.copy()
+        psi, prb = slv.cg_ptycho_batch(
+            data, psi, scan, prb, piter, model, recover_prb)
 
     # Save result
     name = str(model)+str(piter)


### PR DESCRIPTION
Because:
- Using a context manager helps free GPU memory immediately when it's done being used
- Modular code is easier to understand and reuse functions

@math-vrn I suggest going through each commit one-by-one instead of starting with the complete diff for this pull request. I believe that I have broken the changes into small and topical commits that are easy to understand.

I am planning to move this `PtychoCuFFT` class completely to the C++ level, but I ran into some difficulty when trying to implement `__exit__` and type checking of the CuPy arrays because these operations need to be somewhat Python aware. This is a problem for a future week.